### PR TITLE
Device oriented operations on SWKStorage

### DIFF
--- a/Sources/SwanKit/SWKDevice.swift
+++ b/Sources/SwanKit/SWKDevice.swift
@@ -1,0 +1,45 @@
+//
+// SwanKit
+// SWKDevice.swift
+//
+// Created by Dimitri Kurashvili on 2017-10-14
+//
+// Copyright (c) 2017 Dimitri Kurashvili. All rights reserved
+//
+
+/// `SWKDevice` describes device available for computation.
+public enum SWKDevice {
+
+  /// CPU device.
+  case CPU
+
+  /// [Metal](https://developer.apple.com/metal/) enabled GPU device.
+  case Metal
+
+  /// [CUDA](https://developer.nvidia.com/cuda-toolkit) enabled GPU device.
+  case CUDA
+
+  private static var _defaultDevice = SWKDevice.CPU
+
+  /// Currently configured default device.
+  public static var defaultDevice: SWKDevice {
+    get {
+      return _defaultDevice
+    }
+
+    set {
+      _defaultDevice = newValue
+    }
+  }
+
+  /// Is this a CPU device?
+  public var isCPU: Bool {
+    return self == SWKDevice.CPU
+  }
+
+  /// Is this a GPU device?
+  public var isGPU: Bool {
+    return !isCPU
+  }
+
+}

--- a/Sources/SwanKit/SWKStorage.swift
+++ b/Sources/SwanKit/SWKStorage.swift
@@ -13,10 +13,11 @@
 public class SWKStorageBase<T> {
 
   // https://developer.apple.com/documentation/swift/unsafemutablepointer
-  private var _ptr: UnsafeMutablePointer<T>
-
   // https://developer.apple.com/documentation/swift/unsafemutablebufferpointer
+  private var _ptr: UnsafeMutablePointer<T>
   private var _buffer: UnsafeMutableBufferPointer<T>
+
+  fileprivate var _device: SWKDevice?
 
   /// Creates uninitialized storage of given size.
   public init(_ size: Int) {
@@ -37,13 +38,16 @@ public class SWKStorageBase<T> {
 
   public subscript(index: Int) -> T {
     get {
+      assert(index >= 0 && index < size, "Index out of bounds: \(index)", file: #file, line: #line)
       return _buffer[index]
     }
     set {
+      assert(index >= 0 && index < size, "Index out of bounds: \(index)", file: #file, line: #line)
       _buffer[index] = newValue
     }
   }
 
+  /// Number of elements in this storage.
   public var size: Int {
     return _buffer.count
   }
@@ -53,13 +57,39 @@ public class SWKStorageBase<T> {
     return MemoryLayout<T>.stride
   }
 
+  /// Current device for this store.
+  public var device: SWKDevice {
+    if let dev = _device {
+      return dev;
+    }
+
+    return SWKDevice.defaultDevice
+  }
+
+  /// Is storage reeady for CPU?
+  public var isCPU: Bool {
+    return device.isCPU
+  }
+
+  /// Is storage reeady for GPU?
+  public var isGPU: Bool {
+    return device.isGPU
+  }
+
+  /// Converts this storage for use with CPU.
+  public func cpu() -> SWKStorageBase<T> {
+    fatalError("Not implemented", file: #file, line: #line)
+  }
+
+  /// Converts this storage for use with GPU.
+  public func gpu(device: SWKDevice = .Metal) -> SWKStorageBase<T> {
+    fatalError("Not implemented", file: #file, line: #line)
+  }
+
 }
 
 /// Byte storage.
 public typealias SWKByteStorage  = SWKStorageBase<Int8>
-
-/// Character storage.
-public typealias SWKCharStorage  = SWKStorageBase<Character>
 
 /// Short storage.
 public typealias SWKShortStorage = SWKStorageBase<Int16>
@@ -84,7 +114,6 @@ A `SWKStorage` is collection of `Float` data type.
 There are also predefined storages for other primitive data types:
 
 - `SWKByteStorage`, corresponding to Swift's `Int8` type;
-- `SWKCharStorage`, corresponding to Swift's `Character` type;
 - `SWKShortStorage`, corresponding to Swift's `Int16` type;
 - `SWKIntStorage`, corresponding to Swift's `Int32` type;
 - `SWKLongStorage`, corresponding to Swift's `Int64` type;

--- a/Tests/SwanKitTests/SWKDiviceTest.swift
+++ b/Tests/SwanKitTests/SWKDiviceTest.swift
@@ -1,0 +1,40 @@
+//
+// SwanKit
+// SWKDiviceTest.swift
+//
+// Created by Dimitri Kurashvili on 2017-10-14
+//
+// Copyright (c) 2017 Dimitri Kurashvili. All rights reserved
+//
+
+import XCTest
+@testable import SwanKit
+
+class SWKDeviceTest: XCTestCase {
+
+  func testDefaultDevice() {
+    XCTAssertEqual(SWKDevice.defaultDevice, SWKDevice.CPU)
+
+    SWKDevice.defaultDevice = .Metal
+    XCTAssertEqual(SWKDevice.defaultDevice, .Metal)
+  }
+
+  func testIsCPU() {
+    XCTAssertTrue(SWKDevice.CPU.isCPU)
+    XCTAssertFalse(SWKDevice.Metal.isCPU)
+    XCTAssertFalse(SWKDevice.CUDA.isCPU)
+  }
+
+  func testIsGPU() {
+    XCTAssertFalse(SWKDevice.CPU.isGPU)
+    XCTAssertTrue(SWKDevice.Metal.isGPU)
+    XCTAssertTrue(SWKDevice.CUDA.isGPU)
+  }
+
+  static var allTests = [
+    ("testDefaultDevice", testDefaultDevice),
+    ("testIsCPU", testIsCPU),
+    ("testIsGPU", testIsGPU),
+  ]
+
+}

--- a/Tests/SwanKitTests/SWKSizeTest.swift
+++ b/Tests/SwanKitTests/SWKSizeTest.swift
@@ -46,4 +46,5 @@ class SWKSizeTest: XCTestCase {
     ("testPropertyAccess", testPropertyAccess),
     ("testDimensionality", testDimensionality),
   ]
+
 }

--- a/Tests/SwanKitTests/SWKStorageTest.swift
+++ b/Tests/SwanKitTests/SWKStorageTest.swift
@@ -27,9 +27,20 @@ class SWKStorageTest: XCTestCase {
     }
   }
 
+  func testElementSizes() {
+    XCTAssertEqual(SWKByteStorage(1).elementSize,   1)
+    XCTAssertEqual(SWKShortStorage(1).elementSize,  2)
+    XCTAssertEqual(SWKIntStorage(1).elementSize,    4)
+    XCTAssertEqual(SWKLongStorage(1).elementSize,   8)
+
+    XCTAssertEqual(SWKFloatStorage(1).elementSize,  4)
+    XCTAssertEqual(SWKDoubleStorage(1).elementSize, 8)
+  }
+
   static var allTests = [
     ("testInitializationWithSize", testInitializationWithSize),
-    ("testInitializationWithArray", testInitializationWithArray)
+    ("testInitializationWithArray", testInitializationWithArray),
+    ("testElementSizes", testElementSizes)
   ]
 
 }


### PR DESCRIPTION
- [x] `isCPU`
- [x] `isGPU`
- [x] `cpu()`
- [x] `gpu(device:)`

Subtask of #7 