### PR TITLE
Adding capacity property to SWKSize

### DIFF
--- a/Sources/SwanKit/SWKSize.swift
+++ b/Sources/SwanKit/SWKSize.swift
@@ -13,7 +13,8 @@
 You create `SWKSize` by listing all dimension sizes to initializer:
 
 ```swift
-let size = SWKSize(5, 3) // Creates
+let size = SWKSize(5, 3)
+size.capacity // 15
 ````
 
 `dimensions` property gives dimensionality of `SWKSize` instance:
@@ -46,10 +47,12 @@ size.t // Throws Index out of range exception
 public class SWKSize {
 
   private let _dimensions: [Int]
+  public let capacity: Int
 
   /// Creates instance of `SWKSize`.
   public init(_ dimensions: Int...) {
     _dimensions = dimensions
+    capacity = dimensions.reduce(1, { x, y in x * y })
   }
 
   public subscript(index: Int) -> Int {

--- a/Tests/SwanKitTests/SWKSizeTest.swift
+++ b/Tests/SwanKitTests/SWKSizeTest.swift
@@ -41,10 +41,16 @@ class SWKSizeTest: XCTestCase {
     XCTAssertEqual(size.dimensions, 4)
   }
 
+  func testCapacity() {
+    XCTAssertEqual(size.capacity, 24)
+    XCTAssertEqual(SWKSize(1_000, 400, 5).capacity, 2_000_000)
+  }
+
   static var allTests = [
     ("testSubscriptAccess", testSubscriptAccess),
     ("testPropertyAccess", testPropertyAccess),
     ("testDimensionality", testDimensionality),
+    ("testCapacity", testCapacity),
   ]
 
 }


### PR DESCRIPTION
Capacity property returns number of elements which given size can contain:

```swift
let size = SWKSize(5, 3)
print(size.capacity)
// prints 15
```