### PR TITLE
Improve SWKSize

### DIFF
--- a/Sources/SwanKit/Dimensionality.swift
+++ b/Sources/SwanKit/Dimensionality.swift
@@ -1,0 +1,14 @@
+/**
+Cut dimensions on the first non-zero dimension.
+
+```swift
+SWK_cutDimensions([0, 2, 3]) // returns []
+SWK_cutDimensions([1, 0, 3]) // returns [1]
+SWK_cutDimensions([1, 2, 0]) // returns [1, 2]
+SWK_cutDimensions([1, 2, 3]) // returns [1, 2, 3]
+```
+*/
+func SWK_cutDimensions(_ dimensions: [Int]) -> [Int] {
+  let cutOnIndex = dimensions.index { x in x < 1 } ?? dimensions.count
+  return [Int](dimensions[0..<cutOnIndex])
+}

--- a/Sources/SwanKit/SWKSize.swift
+++ b/Sources/SwanKit/SWKSize.swift
@@ -10,49 +10,22 @@
 /**
 `SWKSize` describes tensor size across available dimensions.
 
-You create `SWKSize` by listing all dimension sizes to initializer:
-
 ```swift
 let size = SWKSize(5, 3)
 size.capacity // 15
 ````
-
-`dimensions` property gives dimensionality of `SWKSize` instance:
-
-```swift
-size.dimensions // 2
-```
-
-You can access size of a dimension using subscript operator:
-
-```swift
-size[0] // 5
-size[1] // 3
-```
-
-Or using properties `x` and `y` for two initial dimensions:
-
-```swift
-size.x // 5
-size.y // 3
-```
-
-There are also `z` and `t` properties for third and forth dimensions:
-
-```swift
-size.z // Throws Index out of range exception
-size.t // Throws Index out of range exception
-```
 */
-public class SWKSize {
+public class SWKSize : CustomStringConvertible {
 
   private let _dimensions: [Int]
-  public let capacity: Int
+
+  /// How many elements can tensor of this size contain?
+  public  let capacity:    Int
 
   /// Creates instance of `SWKSize`.
   public init(_ dimensions: [Int]) {
-    _dimensions = dimensions
-    capacity = dimensions.reduce(1, *)
+    _dimensions = SWK_cutDimensions(dimensions)
+    capacity = _dimensions.isEmpty ? 0 : _dimensions.reduce(1, *)
   }
 
   /// Creates instance of `SWKSize`.
@@ -69,24 +42,13 @@ public class SWKSize {
     return _dimensions.count
   }
 
-  /// Size accross first dimension.
-  public var x: Int {
-    return _dimensions[0]
+  /// Empty size?
+  public var isEmpty: Bool {
+    return _dimensions.isEmpty
   }
 
-  /// Size accross second dimension.
-  public var y: Int {
-    return _dimensions[1]
-  }
-
-  /// Size accross third dimension.
-  public var z: Int {
-    return _dimensions[2]
-  }
-
-  /// Size accross forth dimension.
-  public var t: Int {
-    return _dimensions[3]
+  public var description: String {
+    return _dimensions.map({"\($0)"}).joined(separator: "x")
   }
 
 }

--- a/Sources/SwanKit/SWKTensor.swift
+++ b/Sources/SwanKit/SWKTensor.swift
@@ -13,8 +13,19 @@ public class SWKTensorBase<T> {
   private var _storage: SWKStorageBase<T>;
 
   public init(_ dimensions: Int...) {
+    // TODO: assert all dimensions are > 0
     _size = SWKSize(dimensions)
     _storage = SWKStorageBase<T>(_size.capacity)
+  }
+
+  convenience public init(_ arr1: [T]) {
+    self.init(arr1.count)
+    // TODO: init storage
+  }
+
+  convenience public init(_ arr2: [[T]]) {
+    self.init(arr2.count)
+    // TODO: init storage
   }
 
   public subscript(index: Int...) -> T {

--- a/Tests/SwanKitTests/DimensionalityTest.swift
+++ b/Tests/SwanKitTests/DimensionalityTest.swift
@@ -1,0 +1,26 @@
+//
+// SwanKit
+// DimensionalityTest.swift
+//
+// Created by Dimitri Kurashvili on 2017-10-14
+//
+// Copyright (c) 2017 Dimitri Kurashvili. All rights reserved
+//
+
+import XCTest
+@testable import SwanKit
+
+class DimensionalityTest: XCTestCase {
+
+  func test_cutDimensions() {
+    XCTAssertEqual(SWK_cutDimensions([0, 2, 3]), [])
+    XCTAssertEqual(SWK_cutDimensions([1, 0, 3]), [1])
+    XCTAssertEqual(SWK_cutDimensions([1, 2, 0]), [1, 2])
+    XCTAssertEqual(SWK_cutDimensions([1, 2, 3]), [1, 2, 3])
+  }
+
+  static var allTests = [
+    ("test_cutDimensions", test_cutDimensions),
+  ]
+
+}

--- a/Tests/SwanKitTests/SWKDeviceTest.swift
+++ b/Tests/SwanKitTests/SWKDeviceTest.swift
@@ -1,6 +1,6 @@
 //
 // SwanKit
-// SWKDiviceTest.swift
+// SWKDeviceTest.swift
 //
 // Created by Dimitri Kurashvili on 2017-10-14
 //

--- a/Tests/SwanKitTests/SWKSizeTest.swift
+++ b/Tests/SwanKitTests/SWKSizeTest.swift
@@ -24,33 +24,37 @@ class SWKSizeTest: XCTestCase {
     XCTAssertEqual(size[3], 4)
   }
 
-  func testPropertyAccess() {
-    XCTAssertEqual(size.x, 1)
-    XCTAssertEqual(size.y, 2)
-    XCTAssertEqual(size.z, 3)
-    XCTAssertEqual(size.t, 4)
-  }
-
   func testDimensionality() {
-    let s1 = SWKSize(1)
-    let s2 = SWKSize(1, 2)
-    let s3 = SWKSize(1, 2, 3)
-    XCTAssertEqual(s1.dimensions, 1)
-    XCTAssertEqual(s2.dimensions, 2)
-    XCTAssertEqual(s3.dimensions, 3)
+    XCTAssertEqual(SWKSize(1).dimensions, 1)
+    XCTAssertEqual(SWKSize(1, 2).dimensions, 2)
+    XCTAssertEqual(SWKSize(1, 2, 3).dimensions, 3)
+    XCTAssertEqual(SWKSize(1, 2, 3, 0, 5).dimensions, 3)
     XCTAssertEqual(size.dimensions, 4)
   }
 
   func testCapacity() {
     XCTAssertEqual(size.capacity, 24)
     XCTAssertEqual(SWKSize(1_000, 400, 5).capacity, 2_000_000)
+    XCTAssertEqual(SWKSize(1, 2, 3, 0, 10).capacity, 6)
+  }
+
+  func testEmptiness() {
+    XCTAssertFalse(size.isEmpty)
+    XCTAssertTrue(SWKSize().isEmpty)
+    XCTAssertTrue(SWKSize().isEmpty)
+  }
+
+  func testDescription() {
+    XCTAssertEqual(size.description, "1x2x3x4")
+    XCTAssertEqual(SWKSize().description, "")
   }
 
   static var allTests = [
     ("testSubscriptAccess", testSubscriptAccess),
-    ("testPropertyAccess", testPropertyAccess),
     ("testDimensionality", testDimensionality),
     ("testCapacity", testCapacity),
+    ("testEmptiness", testEmptiness),
+    ("testDescription", testDescription),
   ]
 
 }


### PR DESCRIPTION
To better handle `SWKTensor`, we need updates to `SWKSize`:

- [x] `isEmpty` property
- [x] `description` property (as `CustomStringConvertible`)
- [x] cutting negative and zero dimensions
- [x] remove x, y, z, t properties

Part of #15 